### PR TITLE
command line options now use OsStrings

### DIFF
--- a/gio-subclass/src/application.rs
+++ b/gio-subclass/src/application.rs
@@ -11,13 +11,14 @@ use std::fmt;
 use std::mem;
 use std::ops::Deref;
 use std::ptr;
+use std::ffi::OsString;
 
 use gobject_subclass::anyimpl::*;
 use gobject_subclass::object::*;
 
 pub struct ArgumentList {
     pub(crate) ptr: *mut *mut *mut libc::c_char,
-    items: Vec<String>,
+    items: Vec<OsString>,
 }
 
 impl ArgumentList {
@@ -55,7 +56,7 @@ impl ArgumentList {
 }
 
 impl Deref for ArgumentList {
-    type Target = [String];
+    type Target = [OsString];
 
     fn deref(&self) -> &Self::Target {
         self.items.as_slice()
@@ -68,8 +69,8 @@ impl fmt::Debug for ArgumentList {
     }
 }
 
-impl convert::Into<Vec<String>> for ArgumentList {
-    fn into(self) -> Vec<String> {
+impl convert::Into<Vec<OsString>> for ArgumentList {
+    fn into(self) -> Vec<OsString> {
         self.items.clone()
     }
 }

--- a/gio-subclass/tests/simple_application.rs
+++ b/gio-subclass/tests/simple_application.rs
@@ -68,7 +68,9 @@ mod imp {
             let mut rm = Vec::new();
 
             for (i, line) in arguments.iter().enumerate() {
-                if line.starts_with("--local-") {
+                // TODO: we need https://github.com/rust-lang/rust/issues/49802
+                let l = line.clone().into_string().unwrap();
+                if l.starts_with("--local-") {
                     rm.push(i)
                 }
             }
@@ -90,7 +92,9 @@ mod imp {
             let arguments = cmd_line.get_arguments();
 
             for arg in arguments {
-                assert!(!arg.starts_with("--local-"))
+                // TODO: we need https://github.com/rust-lang/rust/issues/49802
+                let a = arg.into_string().unwrap();
+                assert!(!a.starts_with("--local-"))
             }
 
             return EXIT_STATUS;


### PR DESCRIPTION
This is a fix for a change introduced by https://github.com/gtk-rs/gio/commit/efc6c902b6198c02282254dbe2ea891311b70c23.

The solution is not too clean, but there's not a lot we can do as long as https://github.com/rust-lang/rust/issues/49802 hasn't landed.