### PR TITLE
Update Readme.md to include one more example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Example usage of this can be found here
    writing infrastructure
  * [gtk-subclass](https://github.com/sdroege/gtk-subclass): GTK class bindings
  * [Listbox Model Data implementation](https://github.com/gtk-rs/examples/raw/master/src/bin/listbox_model.rs):
-   This is a good, quick example of how to use this crate for gtk-rs related implementations.
+   This is a good, quick example of how to create a GObject conforming struct in Rust.
+   It shows how to make a GObject data class for using with `gio::ListStore` which is then passed to `gtk::ListBox.bind_model()`
 
 This is different to [gnome-class](https://gitlab.gnome.org/federico/gnome-class)
 as it does not require usage of a C#-like DSL in a heavy procedural macro, but

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Example usage of this can be found here
  * [gst-plugin-rs](https://github.com/sdroege/gst-plugin-rs): GStreamer plugin
    writing infrastructure
  * [gtk-subclass](https://github.com/sdroege/gtk-subclass): GTK class bindings
+ * [Listbox Model Data implementation](https://github.com/gtk-rs/examples/raw/master/src/bin/listbox_model.rs):
+   This is a good, quick example of how to use this crate for gtk-rs related implementations.
 
 This is different to [gnome-class](https://gitlab.gnome.org/federico/gnome-class)
 as it does not require usage of a C#-like DSL in a heavy procedural macro, but


### PR DESCRIPTION
For implementing simple subclasses, the code at https://github.com/gtk-rs/examples/raw/master/src/bin/listbox_model.rs is a good  comprehensive example.
It really helped me to improve my understanding of `gobject-subclass`